### PR TITLE
Fix no-audio builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,14 +28,14 @@ endif(NOT FALLEN_ENABLE_AUDIO)
 # Build configuration for Windows desktop.
 if(WIN32)
     # Windows-specifc optional features.
-    set(FALLEN_AUDIO_ENABLE_A3D_BACKEND ON
+    set(FALLEN_AUDIO_ENABLE_A3D_BACKEND OFF
         CACHE BOOL
         "Whether to build support for audio playback via Aureal A3D.")
     # TODO: not sure if DirectSound support was actually implemented...
-    set(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND ON
+    set(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND OFF
         CACHE BOOL
         "Whether to build support for audio playback via DirectSound.")
-    set(FALLEN_AUDIO_ENABLE_QMDX_BACKEND ON
+    set(FALLEN_AUDIO_ENABLE_QMDX_BACKEND OFF
         CACHE BOOL
         "Whether to build support for audio playback via QMDX.")
     if(FALLEN_ENABLE_AUDIO)
@@ -50,7 +50,7 @@ if(WIN32)
             add_definitions(-DA3D_SOUND)
             include_directories(SYSTEM ${IA3DAPI_H_PATH})
         endif(FALLEN_AUDIO_ENABLE_A3D_BACKEND)
-        if(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
+        if(FALLEN_AUDIO_ENABLE_QMDX_BACKEND)
             # Locate the QMDX SDK (it's out there too!).
             message(STATUS "Looking for `qmdx.h`")
             find_path(QMDX_H_PATH qmdx.h
@@ -59,12 +59,12 @@ if(WIN32)
                 message(FATAL_ERROR "could not find `qmdx.h`")
             endif(${QMDX_H_PATH} EQUAL "QMDX_H_PATH-NOTFOUND")
             include_directories(SYSTEM ${QMDX_H_PATH})
-            add_definitions(-DDS_SOUND)
-            link_directories(${QMDX_H_PATH})
-        endif(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
-        if(FALLEN_AUDIO_ENABLE_QMDX_BACKEND)
             add_definitions(-DQ_SOUND)
+            link_directories(${QMDX_H_PATH})
         endif(FALLEN_AUDIO_ENABLE_QMDX_BACKEND)
+        if(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
+            add_definitions(-DDS_SOUND)
+        endif(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
     endif(FALLEN_ENABLE_AUDIO)
     # MSVC users need to install the DirectX SDK (August 2007), as several DirectX components were
     # removed from later SDKs.

--- a/fallen/DDLibrary/CMakeLists.txt
+++ b/fallen/DDLibrary/CMakeLists.txt
@@ -11,12 +11,10 @@ set(DDLIBRARY_HEADERS
     Headers/GDisplay.h
     Headers/GWorkScreen.h
     Headers/MFx.h
-    Headers/QSManager.h
     Headers/Tga.h
     Headers/WindProcs.h
     Headers/net.h)
 set(DDLIBRARY_SOURCES
-    Source/A3DManager.cpp
     Source/BinkClient.cpp
     Source/D3DTexture.cpp
     Source/DCLowLevel.cpp
@@ -31,21 +29,52 @@ set(DDLIBRARY_SOURCES
     Source/GMouse.cpp
     Source/GWorkScreen.cpp
     Source/MFX_DC.cpp
-    Source/QSManager.cpp
     Source/Tga.cpp
     Source/WindProcs.cpp
     Source/net.cpp)
+if(FALLEN_ENABLE_AUDIO)
+    if(FALLEN_AUDIO_ENABLE_A3D_BACKEND)
+        set(DDLIBRARY_AUDIO_HEADERS
+            ${DDLIBRARY_AUDIO_HEADERS}
+            Headers/A3DManager.h)
+        set(DDLIBRARY_AUDIO_SOURCES
+            ${DDLIBRARY_AUDIO_SOURCES}
+            Source/A3DManager.cpp)
+    endif(FALLEN_AUDIO_ENABLE_A3D_BACKEND)
+    if(FALLEN_AUDIO_ENABLE_QMDX_BACKEND)
+        set(DDLIBRARY_AUDIO_HEADERS
+            ${DDLIBRARY_AUDIO_HEADERS}
+            Headers/QSManager.h)
+        set(DDLIBRARY_AUDIO_SOURCES
+            ${DDLIBRARY_AUDIO_SOURCES}
+            Source/QSManager.cpp)
+    endif(FALLEN_AUDIO_ENABLE_QMDX_BACKEND)
+    if(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
+        set(DDLIBRARY_AUDIO_HEADERS
+            ${DDLIBRARY_AUDIO_HEADERS}
+            Headers/DSManager.h)
+        set(DDLIBRARY_AUDIO_SOURCES
+            ${DDLIBRARY_AUDIO_SOURCES}
+            Source/DSManager.cpp)
+    endif(FALLEN_AUDIO_ENABLE_DIRECTSOUND_BACKEND)
+endif(FALLEN_ENABLE_AUDIO)
 set(DDLIBRARY_RESOURCES
     )
 source_group(Headers
-    FILES ${DDLIBRARY_HEADERS})
+    FILES
+        ${DDLIBRARY_HEADERS}
+        ${DDLIBRARY_AUDIO_HEADERS})
 source_group(Source
-    FILES ${DDLIBRARY_SOURCES})
+    FILES
+        ${DDLIBRARY_SOURCES}
+        ${DDLIBRARY_AUDIO_SOURCES})
 source_group(Resources
     FILES ${DDLIBRARY_RESOURCES})
 add_library(DDLibrary STATIC
     ${DDLIBRARY_HEADERS}
+    ${DDLIBRARY_AUDIO_HEADERS}
     ${DDLIBRARY_SOURCES}
+    ${DDLIBRARY_AUDIO_SOURCES}
     ${DDLIBRARY_RESOURCES})
 target_include_directories(DDLibrary
     PUBLIC Headers

--- a/fallen/DDLibrary/Headers/A3DManager.h
+++ b/fallen/DDLibrary/Headers/A3DManager.h
@@ -6,7 +6,7 @@
 // requires either Aureal 3D sound card + drivers, OR normal sound card with A2D installed
 
 
-#ifndef _A3D_MANAGER_H_
+#if !defined(NO_SOUND) && defined(A3D_SOUND) && !defined(_A3D_MANAGER_H_)
 #define _A3D_MANAGER_H_
 
 

--- a/fallen/DDLibrary/Headers/QSManager.h
+++ b/fallen/DDLibrary/Headers/QSManager.h
@@ -1,7 +1,7 @@
 //	QSManager.h
 //	Guy Simmons, 6th May 1998.
 
-#ifndef	QSMANAGER_H
+#if !defined(NO_SOUND) && defined(Q_SOUND) && !defined(QSMANAGER_H)
 #define	QSMANAGER_H
 
 //---------------------------------------------------------------

--- a/fallen/Headers/Sound.h
+++ b/fallen/Headers/Sound.h
@@ -7,7 +7,9 @@
 #include "Structs.h"
 #include "MFX.h"
 
+#if !defined(NO_SOUND) && defined(A3D_SOUND)
 #define USE_A3D
+#endif
 
 // because the versions in MFStdLib.h are misspelt...
 #define	WAVE_PLAY_INTERRUPT		0


### PR DESCRIPTION
No-audio builds didn't work because I didn't bother to test them. Oops.

Should be fixed now, but mixing and matching is probably still broken.